### PR TITLE
implement support for multiple transactions under the calculate endpoint

### DIFF
--- a/src/Carbonara/Controllers/CarbonaraController.cs
+++ b/src/Carbonara/Controllers/CarbonaraController.cs
@@ -70,21 +70,21 @@ namespace Carbonara.Controllers
         }
 
         /// <summary>
-        /// Get the CO2 emission for a given transaction hash
+        /// Get the CO2 emission for a given transaction hash list
         /// </summary>
-        /// <param name="txHash">transaction hash</param>
+        /// <param name="txHashes">a list of transaction hashes</param>
         /// <param name="hashingAlgorithm">(Optional) Hashing alg to be used for the minning gear approximation.
         /// Currently ignored and defaults to SHA256 </param>
         /// <param name="cO2EmissionCountry">(Optional) Country for which the CO2 emission per KWH appoximation should be taken into account.</param>
-        /// <response code="200">Returns an approximation of the CO2 emmission in KG for the given transaction hash as well as the energy consumption
+        /// <response code="200">Returns an approximation of the CO2 emmission in KG for the given transactions as well as the energy consumption
         /// per regions and average CO2 emission per region </response>
         [HttpGet("Calculation")]
         public async Task<IActionResult> GetCalculationAsync(
-            [FromQuery(Name = "TxHash")]string txHash,
+            [FromQuery(Name = "txHashes")]List<string> txHashes,
             [FromQuery(Name = "HashingAlgorithm")]string hashingAlgorithm = "0",
             [FromQuery(Name = "CO2EmissionCountry")]string cO2EmissionCountry = null)
         {
-            var result = await _calculationService.Calculate(txHash, hashingAlgorithm, cO2EmissionCountry);
+            var result = await _calculationService.CalculateTotalSummary(txHashes, hashingAlgorithm, cO2EmissionCountry);
             return Ok(result);
         }
 

--- a/src/Carbonara/Models/Calculation/TotalCalculationResult.cs
+++ b/src/Carbonara/Models/Calculation/TotalCalculationResult.cs
@@ -7,11 +7,14 @@ namespace Carbonara.Models.Calculation
     {
         public Dictionary<int, CalculationResult> CalculationPerYear;
         public List<Country.Country> AverageCo2EmissionPerCountryInKg;
-        public DateTime transactionDate; 
+        public List<KeyValuePair<string, DateTime>> TransactionDates; 
         public TotalCalculationResult()
         {
             if (CalculationPerYear == null)
                 CalculationPerYear = new Dictionary<int, CalculationResult>();
+
+            if (TransactionDates == null)
+                TransactionDates = new List<KeyValuePair<string, DateTime>>();
         }
     }
 }

--- a/src/Carbonara/Services/CalculationService/ICalculationService.cs
+++ b/src/Carbonara/Services/CalculationService/ICalculationService.cs
@@ -4,7 +4,9 @@ using Carbonara.Models.Calculation;
 
 namespace Carbonara.Services.CalculationService
 {
-    public interface ICalculationService {
+    public interface ICalculationService
+    {
+        Task<TotalCalculationResult> CalculateTotalSummary(List<string> txHashes, string hashingAlg, string countryToUseForCo2EmissionAverage);
         Task<TotalCalculationResult> Calculate(string txHash, string hashingAlg, string cO2EmissionCountry);
         Task<decimal> CalculateBlockEnergyConsumptionAsync(string blockHash);
     }


### PR DESCRIPTION
updated the /calculate endpoint to accept a List of transactions instead of only one. updated tests for that.

The AverageCo2EmissionPerCountryInKg property does not get updated for every transaction but gets its value from the first one (as it is an average). Its values originate from the db currently anyway.